### PR TITLE
Fix CreditRoute guide PDF session handoff

### DIFF
--- a/netlify/functions/export-plan-pdf.js
+++ b/netlify/functions/export-plan-pdf.js
@@ -1,6 +1,7 @@
 // netlify/functions/export-plan-pdf.js
 import fs from "node:fs/promises";
 import path from "node:path";
+import { timingSafeEqual } from "node:crypto";
 import chromium from "@sparticuz/chromium";
 import puppeteer from "puppeteer-core";
 import Stripe from "stripe";
@@ -45,6 +46,44 @@ function logPdfError(stage, err, details = {}) {
       stack: err?.stack || "",
     })
   );
+}
+
+function getHeader(headers, name) {
+  const lower = String(name || "").toLowerCase();
+  for (const key of Object.keys(headers || {})) {
+    if (String(key).toLowerCase() === lower) return headers[key];
+  }
+  return "";
+}
+
+function safeEqual(a, b) {
+  const left = Buffer.from(String(a || ""));
+  const right = Buffer.from(String(b || ""));
+  return left.length === right.length && timingSafeEqual(left, right);
+}
+
+function idTail(value = "") {
+  return String(value || "").slice(-8);
+}
+
+function isDeployPreviewRequest(event) {
+  const context = String(process.env.CONTEXT || "").toLowerCase();
+  const host = String(
+    getHeader(event.headers, "x-forwarded-host") ||
+      getHeader(event.headers, "host") ||
+      ""
+  ).toLowerCase();
+
+  return (
+    context === "deploy-preview" ||
+    (/^deploy-preview-\d+--/.test(host) && host.endsWith(".netlify.app"))
+  );
+}
+
+function hasAuthorizedDevPdfSecret(event) {
+  const secret = process.env.TEST_DELIVERY_EMAIL_SECRET || "";
+  const provided = getHeader(event.headers, "x-creditroute-dev-pdf-secret");
+  return Boolean(secret && provided && safeEqual(provided, secret));
 }
 
 function parseRequestBody(rawBody) {
@@ -459,7 +498,14 @@ async function loadLogoSrc() {
 }
 
 async function verifyPaidSession(sessionId) {
-  if (!sessionId) throw new Error("Missing session_id");
+  if (!sessionId) {
+    const err = new Error("Missing session_id");
+    logPdfError("verify-paid-session", err, {
+      reason: "missing_session_id",
+    });
+    throw err;
+  }
+
   if (!process.env.STRIPE_SECRET_KEY) {
     throw new Error("Missing STRIPE_SECRET_KEY");
   }
@@ -468,10 +514,25 @@ async function verifyPaidSession(sessionId) {
     apiVersion: "2024-06-20",
   });
 
-  const session = await stripeClient.checkout.sessions.retrieve(sessionId);
+  let session;
+  try {
+    session = await stripeClient.checkout.sessions.retrieve(sessionId);
+  } catch (err) {
+    logPdfError("verify-paid-session", err, {
+      reason: "stripe_retrieve_failed",
+      sessionIdTail: idTail(sessionId),
+    });
+    throw err;
+  }
 
   if (session.payment_status !== "paid") {
-    throw new Error("Session not paid");
+    const err = new Error("Session not paid");
+    logPdfError("verify-paid-session", err, {
+      reason: "session_not_paid",
+      sessionIdTail: idTail(sessionId),
+      paymentStatus: session.payment_status || "",
+    });
+    throw err;
   }
 
   return session;
@@ -634,11 +695,26 @@ export const handler = async (event) => {
       .toLowerCase()
       .trim();
 
-    const isAllowedDevPdf =
+    const requestedDevPdf =
       String(body.dev || query.dev || "") === "1" &&
       DEV_QA_STACK_KEYS.has(requestedStackKey);
+    const isAllowedDevPdf =
+      requestedDevPdf &&
+      (isDeployPreviewRequest(event) || hasAuthorizedDevPdfSecret(event));
 
     if (!sessionId && !isAllowedDevPdf) {
+      logPdfInfo("session-verification-missing", {
+        method,
+        requestedStackKey,
+        requestedDevPdf,
+        isDeployPreview: isDeployPreviewRequest(event),
+        hasAuthorizedDevPdfSecret: hasAuthorizedDevPdfSecret(event),
+      });
+      if (requestedDevPdf) {
+        return json({}, 403, {
+          error: "Dev PDF bypass is only available on deploy previews.",
+        });
+      }
       return json({}, 400, { error: "Missing session_id" });
     }
 

--- a/netlify/functions/verify-guide-token.js
+++ b/netlify/functions/verify-guide-token.js
@@ -38,6 +38,17 @@ function b64urlDecode(value = "") {
   return Buffer.from(padded, "base64").toString("utf8");
 }
 
+function tokenTail(token = "") {
+  return String(token || "").slice(-8);
+}
+
+function logTokenRejection(reason, details = {}) {
+  console.warn("verify-guide-token rejected:", {
+    reason,
+    ...details,
+  });
+}
+
 export const handler = async (event) => {
   try {
     if (!process.env.GUIDE_TOKEN_SECRET) {
@@ -77,6 +88,10 @@ export const handler = async (event) => {
       .trim();
 
     if (!token || !token.includes(".")) {
+      logTokenRejection("missing_or_invalid_token", {
+        hasToken: Boolean(token),
+        requestedStackKey,
+      });
       return json(401, {
         ok: false,
         error: "Missing or invalid token",
@@ -85,6 +100,10 @@ export const handler = async (event) => {
 
     const [encoded, signature] = token.split(".");
     if (!encoded || !signature) {
+      logTokenRejection("malformed_token", {
+        tokenTail: tokenTail(token),
+        requestedStackKey,
+      });
       return json(401, {
         ok: false,
         error: "Malformed token",
@@ -94,6 +113,10 @@ export const handler = async (event) => {
     const expected = sign(encoded, process.env.GUIDE_TOKEN_SECRET);
 
     if (signature !== expected) {
+      logTokenRejection("bad_signature", {
+        tokenTail: tokenTail(token),
+        requestedStackKey,
+      });
       return json(401, {
         ok: false,
         error: "Bad signature",
@@ -104,6 +127,10 @@ export const handler = async (event) => {
     try {
       payload = JSON.parse(b64urlDecode(encoded));
     } catch {
+      logTokenRejection("invalid_payload", {
+        tokenTail: tokenTail(token),
+        requestedStackKey,
+      });
       return json(401, {
         ok: false,
         error: "Invalid token payload",
@@ -113,6 +140,12 @@ export const handler = async (event) => {
     const now = Math.floor(Date.now() / 1000);
 
     if (!payload?.exp || now > payload.exp) {
+      logTokenRejection("token_expired", {
+        tokenTail: tokenTail(token),
+        requestedStackKey,
+        exp: payload?.exp || 0,
+        now,
+      });
       return json(401, {
         ok: false,
         error: "Token expired",
@@ -124,6 +157,11 @@ export const handler = async (event) => {
       payload?.stackKey &&
       String(payload.stackKey).toLowerCase().trim() !== requestedStackKey
     ) {
+      logTokenRejection("stack_mismatch", {
+        tokenTail: tokenTail(token),
+        requestedStackKey,
+        tokenStackKey: String(payload.stackKey).toLowerCase().trim(),
+      });
       return json(401, {
         ok: false,
         error: "Stack mismatch",

--- a/public/guides/82.html
+++ b/public/guides/82.html
@@ -18,18 +18,24 @@
     const requestedStackKey = String(params.get("stackKey") || "").toLowerCase().trim();
     const stackKey = requestedStackKey || "growth";
     const sessionId = params.get("session_id") || "";
-    const isAllowedDevGuide = params.get("dev") === "1" && allowedDevStackKeys.has(requestedStackKey);
+    const isDeployPreview =
+      /^deploy-preview-\d+--/.test(window.location.hostname) &&
+      window.location.hostname.endsWith(".netlify.app");
+    const isAllowedDevGuide =
+      params.get("dev") === "1" &&
+      allowedDevStackKeys.has(requestedStackKey) &&
+      isDeployPreview;
 
     document.documentElement.style.visibility = "hidden";
 
-    function persistRouteContext() {
+    function persistRouteContext(verifiedSessionId) {
       try {
         localStorage.setItem("ss_route_key", String(stackKey || "growth").toLowerCase());
         sessionStorage.setItem("selectedPlanKey", String(stackKey || "growth").toLowerCase());
         sessionStorage.setItem("ss_selected", JSON.stringify(String(stackKey || "growth").toLowerCase()));
-        if (sessionId) {
-          localStorage.setItem("ss_last_session_id", sessionId);
-          sessionStorage.setItem("ss_last_session_id", sessionId);
+        if (verifiedSessionId) {
+          localStorage.setItem("ss_last_session_id", verifiedSessionId);
+          sessionStorage.setItem("ss_last_session_id", verifiedSessionId);
         }
       } catch {}
     }
@@ -37,11 +43,16 @@
     async function verify() {
       try {
         if (!token && !isAllowedDevGuide) {
+          console.warn("CreditRoute guide access denied: missing guide token", {
+            stackKey,
+            hasSessionId: Boolean(sessionId)
+          });
           window.location.replace("/activate");
           return;
         }
 
         if (!token) {
+          persistRouteContext(sessionId);
           document.documentElement.style.visibility = "visible";
           return;
         }
@@ -54,19 +65,37 @@
         const data = await res.json().catch(() => ({}));
 
         if (!res.ok || !data?.ok) {
+          console.warn("CreditRoute guide token verification failed", {
+            status: res.status,
+            error: data?.error || "Unknown verification error",
+            stackKey,
+            hasSessionId: Boolean(sessionId)
+          });
           window.location.replace("/activate");
           return;
         }
 
-        persistRouteContext();
+        const verifiedSessionId = String(data?.session_id || sessionId || "").trim();
+        if (!verifiedSessionId) {
+          console.warn("CreditRoute guide token verified without session_id", {
+            stackKey
+          });
+        }
+
+        persistRouteContext(verifiedSessionId);
 
         const cleanParams = new URLSearchParams();
         cleanParams.set("stackKey", stackKey);
-        if (sessionId) cleanParams.set("session_id", sessionId);
+        if (verifiedSessionId) cleanParams.set("session_id", verifiedSessionId);
 
         history.replaceState({}, "", `/guides/82.html?${cleanParams.toString()}`);
         document.documentElement.style.visibility = "visible";
-      } catch {
+      } catch (err) {
+        console.warn("CreditRoute guide token verification error", {
+          error: err?.message || String(err),
+          stackKey,
+          hasSessionId: Boolean(sessionId)
+        });
         window.location.replace("/activate");
       }
     }
@@ -703,8 +732,11 @@
         ).toLowerCase().trim();
         const allowedDevStackKeys = new Set(["foundation", "growth", "accelerator"]);
         const requestedStackKey = String(params.get("stackKey") || "").toLowerCase().trim();
+        const isDeployPreview =
+          /^deploy-preview-\d+--/.test(window.location.hostname) &&
+          window.location.hostname.endsWith(".netlify.app");
         const isAllowedDevPdf =
-          params.get("dev") === "1" && allowedDevStackKeys.has(requestedStackKey);
+          params.get("dev") === "1" && allowedDevStackKeys.has(requestedStackKey) && isDeployPreview;
 
         return {
           stackKey,
@@ -729,6 +761,12 @@
         const { stackKey, sessionId, dev } = currentContext();
         const isAllowedDevPdf = dev === "1";
         if (!sessionId && !isAllowedDevPdf) {
+          console.warn("CreditRoute PDF download blocked: missing paid session", {
+            stackKey,
+            hasUrlSessionId: new URLSearchParams(window.location.search).has("session_id"),
+            hasSessionStorageSessionId: Boolean(sessionStorage.getItem("ss_last_session_id")),
+            hasLocalStorageSessionId: Boolean(localStorage.getItem("ss_last_session_id"))
+          });
           window.alert("We could not find your paid session. Please reopen your CreditRoute from the success page or email link.");
           return;
         }

--- a/public/success.html
+++ b/public/success.html
@@ -109,13 +109,18 @@
       return data;
     }
 
-    function setRouteContext({ email, stackKey }) {
+    function setRouteContext({ email, stackKey, sessionId }) {
       try {
         const key = String(stackKey || "growth").toLowerCase().trim();
 
         localStorage.setItem("stackscore_paid", "1");
         localStorage.setItem("ss_access", "1");
         localStorage.setItem("ss_route_key", key);
+
+        if (sessionId) {
+          localStorage.setItem("ss_last_session_id", sessionId);
+          sessionStorage.setItem("ss_last_session_id", sessionId);
+        }
 
         if (email) {
           localStorage.setItem("stackscore_paid_email", email);
@@ -132,9 +137,9 @@
       } catch {}
     }
 
-    function showContinue(stackKey, token) {
+    function showContinue(stackKey, token, verifiedSessionId) {
       const key = String(stackKey || "growth").toLowerCase().trim();
-      const target = `/guides/82.html?stackKey=${encodeURIComponent(key)}&t=${encodeURIComponent(token)}`;
+      const target = `/guides/82.html?stackKey=${encodeURIComponent(key)}&t=${encodeURIComponent(token)}&session_id=${encodeURIComponent(verifiedSessionId || sessionId)}`;
 
       goBtn.classList.remove("hidden");
       goBtn.onclick = () => {
@@ -168,17 +173,18 @@
           return;
         }
 
-        setRouteContext({ email, stackKey });
+        setRouteContext({ email, stackKey, sessionId });
 
         statusEl.textContent = "Creating secure access…";
 
         const tokenData = await getGuideToken();
         const token = tokenData.token;
+        const verifiedSessionId = tokenData.session_id || sessionId;
 
-        const target = `/guides/82.html?stackKey=${encodeURIComponent(stackKey)}&t=${encodeURIComponent(token)}`;
+        const target = `/guides/82.html?stackKey=${encodeURIComponent(stackKey)}&t=${encodeURIComponent(token)}&session_id=${encodeURIComponent(verifiedSessionId)}`;
 
         statusEl.textContent = "Activated. Redirecting to your route…";
-        showContinue(stackKey, token);
+        showContinue(stackKey, token, verifiedSessionId);
 
         setTimeout(() => {
           location.href = target;
@@ -186,7 +192,7 @@
 
         setTimeout(() => {
           statusEl.textContent = "If you are not redirected automatically, click below.";
-          showContinue(stackKey, token);
+          showContinue(stackKey, token, verifiedSessionId);
         }, 2500);
       } catch (e) {
         console.error(e);

--- a/server/lib/creditrouteDeliveryEmail.js
+++ b/server/lib/creditrouteDeliveryEmail.js
@@ -119,6 +119,12 @@ async function fetchPdfAttachment({
     headers: {
       "Content-Type": "application/json",
       Accept: "application/pdf",
+      ...(devPdf && process.env.TEST_DELIVERY_EMAIL_SECRET
+        ? {
+            "x-creditroute-dev-pdf-secret":
+              process.env.TEST_DELIVERY_EMAIL_SECRET,
+          }
+        : {}),
     },
     body: JSON.stringify(body),
   });


### PR DESCRIPTION
## Summary
- Preserve the paid Stripe `session_id` when success redirects customers into the online guide.
- Recover and persist `session_id` from verified guide tokens so token-only guide links can still download PDFs.
- Add clearer token/session verification logging.
- Restrict unauthenticated `dev=1` PDF/guide bypass to Netlify Deploy Previews, while keeping the guarded server-side test path available via secret header.

## Validation
- `node --check netlify/functions/export-plan-pdf.js && node --check netlify/functions/verify-guide-token.js && node --check server/lib/creditrouteDeliveryEmail.js`
- `git diff --check`
- `npm run build`
- `npx esbuild netlify/functions/export-plan-pdf.js --bundle --platform=node --format=esm --outfile=/tmp/export-plan-pdf.mjs`
- `npx esbuild netlify/functions/verify-guide-token.js --bundle --platform=node --format=esm --outfile=/tmp/verify-guide-token.mjs`
- Local production-host probe confirms `dev=1` PDF bypass returns 403 without a paid session or server-side secret.